### PR TITLE
Support MySQL by treating usernames as case-insensitive

### DIFF
--- a/api/user/user.js
+++ b/api/user/user.js
@@ -20,12 +20,12 @@ exports.create = function(req, res) {
   } else if (!validator.isAlphanumeric(req.body.username)) {
     res.send({success: false, error: 'username must contain only letters and numbers'});
   } else {
-    models.User.find({ where: {username: {ilike: req.body.username}} }).then(function(user) {
+    models.User.find({ where: {username: req.body.username.toLowerCase()}}).then(function(user) {
       if (user) {
         res.send({success: false, error: 'username already taken'});
       } else {
         models.User.hash(req.body.password, function(err, hash){
-          models.User.create({ username: req.body.username, password: hash }).then(function(user) {
+          models.User.create({ username: req.body.username.toLowerCase(), password: hash }).then(function(user) {
             models.UserMeta.create({}).then(function(usermeta){
               usermeta.setUser(user);
               req.session.userID = user.id;
@@ -42,7 +42,7 @@ exports.authenticate = function(req, res) {
   if (!req.body.username || !req.body.password) {
     res.send({success: false, error: 'fields left empty'});
   } else {
-    models.User.find({ where: {username: {ilike: req.body.username}} }).then(function(user) {
+    models.User.find({ where: {username: req.body.username.toLowerCase()}}).then(function(user) {
       if (!user) {
         res.send({success: false, error: 'user not found'});
       } else {
@@ -53,7 +53,7 @@ exports.authenticate = function(req, res) {
             user.getUserMetum().then(function(usermeta){
               req.session.userID = user.id;
               res.send({success: true, user: buildReplyUser(user, usermeta)});
-            }); 
+            });
           }
         });
       }
@@ -67,7 +67,7 @@ exports.session = function(req, res) {
       user.getUserMetum().then(function(usermeta){
         res.send({success: true, user: buildReplyUser(user, usermeta)});
       });
-    }); 
+    });
   } else {
     debug('session expired');
     res.send({success: false, error: 'session expired'});


### PR DESCRIPTION
MySQL performs case-insensitive search by default, whereas PostgreSQL requires the `ILIKE` keyword to force case-insensitivity. The solution suggested here is to treat usernames as case-insensitive. This is implemented by automatically applying `.toLowerCase()` to the username provided when creating the user and when validating logins. One implication of this is that the usernames `andrew` and `Andrew` would now be considered the same username, which is probably preferable anyway as it avoids confusion (e.g.: 'did I type it with a capital 'A' when I signed up?').